### PR TITLE
Temporary change to take a try for t4u v3 ac1300

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -233,6 +233,8 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 
 #ifdef CONFIG_RTL8822B
 	/*=== Realtek demoboard ===*/
+		
+        {USB_DEVICE(0x2357, 0x0115), .driver_info = RTL8822B}, /* TP-LINK - T4Uv3 */
 	{USB_DEVICE(0x0B05, 0x1812), .driver_info = RTL8812}, /* ASUS - Edimax */
 	{USB_DEVICE(0x7392, 0xB822), .driver_info = RTL8822B}, /* Edimax - EW-7822ULC */
 	{USB_DEVICE(0x0b05, 0x184c), .driver_info = RTL8822B}, /* ASUS USB AC53 Nano */


### PR DESCRIPTION
Temporary change to take a try for t4u v3 ac1300.  If it is not effective, the file just go back to its original. if it is, will make a recommendation for change to the author.

Yes, it seems that the patch can work on extension to TP-link T4u V3 ac1300 wireless wifi adaptor.

Now we have two repositories with suitable installation process and prarmeters work smoothly for T4u V3.
Isn't  it? I am just a user only so far, i don't know how to write a program, only using some thoughts to finish that I know not that much.
Please tell somebody that he is not correct. Thank you.